### PR TITLE
Fix crash on incomplete regex search and make search case-insensitive

### DIFF
--- a/internal/explore/tree_view.go
+++ b/internal/explore/tree_view.go
@@ -22,7 +22,10 @@ func SearchTreeView(repo string, gt GitTree, treeView *tview.TreeView) func(stri
 		root := treeView.GetRoot()
 		root.ClearChildren()
 		dirs := map[string]*tview.TreeNode{".": root}
-		r := regexp.MustCompile(query)
+		r, err := regexp.Compile(query)
+		if err != nil {
+			return
+		}
 
 		for _, n := range gt {
 			if n.IsDir() || !r.MatchString(n.Path) {

--- a/internal/explore/tree_view.go
+++ b/internal/explore/tree_view.go
@@ -22,7 +22,7 @@ func SearchTreeView(repo string, gt GitTree, treeView *tview.TreeView) func(stri
 		root := treeView.GetRoot()
 		root.ClearChildren()
 		dirs := map[string]*tview.TreeNode{".": root}
-		r, err := regexp.Compile(query)
+		r, err := regexp.Compile("(?i)" + query)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Input a backslash will crash the program:

```
panic: regexp: Compile(`\`): error parsing regexp: trailing backslash at end of expression: `` [recovered]
        panic: regexp: Compile(`\`): error parsing regexp: trailing backslash at end of expression: ``
```

I also took the chance to make the search case-insensitive since that makes sense most.