### PR TITLE
Fix search box display

### DIFF
--- a/internal/explore/search_view.go
+++ b/internal/explore/search_view.go
@@ -4,7 +4,6 @@ import "github.com/rivo/tview"
 
 func BuildSearchView(repo string) *tview.InputField {
 	searchView := tview.NewInputField()
-	searchView.SetBorder(true)
 	searchView.SetLabel(repo)
 	searchView.SetFieldBackgroundColor(0)
 	searchView.SetLabelWidth(len(repo) + 1)


### PR DESCRIPTION
It seems `SetBorder` doesn't work with tview's inputfield, and will prevent the search box from displaying (leaving a border box only).