### PR TITLE
fixes to shell script

### DIFF
--- a/gh-repo-explore
+++ b/gh-repo-explore
@@ -3,33 +3,34 @@ set -e
 
 tag="v0.0.4"
 repo="samcoe/gh-repo-explore"
-extension_path="$(dirname "$0")"
+extension_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 tag_path="${extension_path}/dist/${tag}"
 exe="gh-repo-explore"
 platform=""
 extension=""
 
 determine_platform() {
-  local arch="$(uname -m)"
+  local arch
+  arch="$(uname -m)"
   if uname -a | grep Msys > /dev/null; then
     extension=".exe"
-    if [ $arch == "x86_64" ]; then
+    if [ "$arch" == "x86_64" ]; then
       platform="windows_amd64"
-    elif [ $arch == "i686" ]; then
+    elif [ "$arch" == "i686" ]; then
       platform="windows_386"
-    elif [ $arch == "i386" ]; then
+    elif [ "$arch" == "i386" ]; then
       platform="windows_386"
     fi
   elif uname -a | grep Darwin > /dev/null; then
-    if [ $arch == "x86_64" ]; then
+    if [ "$arch" == "x86_64" ]; then
       platform="darwin_amd64"
     fi
   elif uname -a | grep Linux > /dev/null; then
-    if [ $arch == "x86_64" ]; then
+    if [ "$arch" == "x86_64" ]; then
       platform="linux_amd64"
-    elif [ $arch == "i686" ]; then
+    elif [ "$arch" == "i686" ]; then
       platform="linux_386"
-    elif [ $arch == "i386" ]; then
+    elif [ "$arch" == "i386" ]; then
       platform="linux_386"
     fi
   fi
@@ -42,20 +43,22 @@ download_latest_release() {
   chmod +x "${tag_path}/${exe}"
 }
 
-determine_platform
+if [ ! -e "${tag_path}/${exe}" ]; then
+  determine_platform
 
-if [ "${platform}" == "" ]; then
-  if [ "$(which go)" == "" ]; then
-    echo "go must be installed to use this gh extension on this platform"
-    exit 1
-  fi
-  mkdir -p "${tag_path}"
-  cd "${extensionPath}" > /dev/null
-  go build -o "${tag_path}/${exe}"
-  cd - > /dev/null
-else
-  if [ ! -d "${tag_path}" ]; then
-    download_latest_release
+  if [ "${platform}" == "" ]; then
+    if [ "$(which go)" == "" ]; then
+      echo "go must be installed to use this gh extension on this platform"
+      exit 1
+    fi
+    mkdir -p "${tag_path}"
+    pushd "${extension_path}" > /dev/null
+    go build -o "${tag_path}/${exe}"
+    popd > /dev/null
+  else
+    if [ ! -d "${tag_path}" ]; then
+      download_latest_release
+    fi
   fi
 fi
 


### PR DESCRIPTION
- fix typo extensionPath -> extension_path
- use more portable method for getting extension_path
- fix shellcheck warnings about quoting
- optimization: check for exe before trying to build or download it


I got this on an M1 (`arm64`) Mac. 
```
% gh extension install samcoe/gh-repo-explore
% gh repo-explore samcoe/gh-repo-explore
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
```

It is working now with these changes.